### PR TITLE
Add ModernColBERT support and update tokenizer warnings

### DIFF
--- a/lightning_ir/bi_encoder/bi_encoder_tokenizer.py
+++ b/lightning_ir/bi_encoder/bi_encoder_tokenizer.py
@@ -60,7 +60,7 @@ class BiEncoderTokenizer(LightningIRTokenizer):
         if add_marker_tokens:
             # TODO support other tokenizers
             if not isinstance(self, (BertTokenizer, BertTokenizerFast)):
-                raise ValueError("Adding marker tokens is only supported for BertTokenizer.")
+                warnings.warn(f"Adding marker tokens may not be supported for {type(self)}.")
             self.add_tokens([self.QUERY_TOKEN, self.DOC_TOKEN], special_tokens=True)
             self.query_post_processor = TemplateProcessing(
                 single=f"[CLS] {self.QUERY_TOKEN} $0 [SEP]",

--- a/tests/test_models/test_col.py
+++ b/tests/test_models/test_col.py
@@ -6,6 +6,8 @@ transformers.AdamW = None
 from colbert.modeling.checkpoint import Checkpoint  # noqa: E402
 from colbert.modeling.colbert import ColBERTConfig, colbert_score  # noqa: E402
 
+from pylate import models, rank
+
 from lightning_ir import BiEncoderModule  # noqa: E402
 
 
@@ -35,3 +37,34 @@ def test_same_as_colbert():
     assert torch.allclose(query_embedding.embeddings, orig_query, atol=1e-6)
     assert torch.allclose(doc_embedding.embeddings[doc_embedding.scoring_mask], orig_docs[d_mask], atol=1e-6)
     assert torch.allclose(output.scores, orig_scores, atol=1e-6)
+
+
+def test_same_as_modern_colbert():
+    query = "What is the capital of France?"
+    documents = [
+        "Paris is the capital of France.",
+        "France is a country in Europe.",
+        "The Eiffel Tower is in Paris.",
+    ]
+
+    model_name = "lightonai/GTE-ModernColBERT-v1"
+    module = BiEncoderModule(model_name).eval()
+    with torch.inference_mode():
+        output = module.score(query, documents)
+    query_embedding = output.query_embeddings
+    doc_embedding = output.doc_embeddings
+
+    orig_model = models.ColBERT(model_name_or_path=model_name)
+    orig_query = orig_model.encode(
+        [query],
+        is_query=True,
+    )
+    orig_docs = orig_model.encode(
+        [documents],
+        is_query=False,
+    )
+    orig_scores = rank.rerank(queries_embeddings=orig_query, documents_embeddings=orig_docs, documents_ids=[list(range(len(documents)))])
+
+    assert torch.allclose(query_embedding.embeddings, torch.tensor(orig_query[0]), atol=1e-6)
+    assert torch.allclose(doc_embedding.embeddings[doc_embedding.scoring_mask], torch.cat([torch.from_numpy(d) for doc in orig_docs for d in doc]), atol=1e-6)
+    assert torch.allclose(output.scores, torch.tensor([d["score"] for q in orig_scores for d in q]), atol=1e-6)


### PR DESCRIPTION
Introduce support for the ModernColBERT model in external models registration and testing. Update the warning message for unsupported marker tokens in the BiEncoderTokenizer to provide clearer guidance.