### PR TITLE
Make query and doc length optional + cleanup (cross-encoder) tokenizer

### DIFF
--- a/lightning_ir/base/config.py
+++ b/lightning_ir/base/config.py
@@ -44,8 +44,8 @@ https://huggingface.co/transformers/main_classes/configuration.html#transformers
     def __init__(
         self,
         *args,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         use_adapter: bool = False,
         adapter_config: Optional["LoraConfig"] = None,
         pretrained_adapter_name_or_path: Optional[str] = None,
@@ -54,8 +54,8 @@ https://huggingface.co/transformers/main_classes/configuration.html#transformers
         """Initializes the configuration.
 
         Args:
-            query_length (int, optional): Maximum query length. Defaults to 32.
-            doc_length (int, optional): Maximum document length. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             use_adapter (bool, optional): Whether to use LoRA adapters. Defaults to False.
             adapter_config (Optional[LoraConfig], optional): Configuration for LoRA adapters.
                 Only used if use_adapter is True. Defaults to None.

--- a/lightning_ir/base/module.py
+++ b/lightning_ir/base/module.py
@@ -225,7 +225,7 @@ class LightningIRModule(LightningModule):
         Args:
             batch (TrainBatch | RankBatch | SearchBatch): Batch of validation or testing data.
             batch_idx (int): Index of the batch.
-            dataloader_idx (int, optional): Index of the dataloader. Defaults to 0.
+            dataloader_idx (int | None): Index of the dataloader. Defaults to 0.
         Returns:
             LightningIROutput: Model output.
         """
@@ -253,7 +253,7 @@ class LightningIRModule(LightningModule):
         Args:
             batch (TrainBatch | RankBatch): Batch of testing data.
             batch_idx (int): Index of the batch.
-            dataloader_idx (int, optional): Index of the dataloader. Defaults to 0.
+            dataloader_idx (int | None): Index of the dataloader. Defaults to 0.
         Returns:
             LightningIROutput: Model output.
         """

--- a/lightning_ir/base/tokenizer.py
+++ b/lightning_ir/base/tokenizer.py
@@ -26,12 +26,12 @@ https://huggingface.co/transformers/main_classes/tokenizer.htmltransformers.PreT
     config_class: Type[LightningIRConfig] = LightningIRConfig
     """Configuration class for the tokenizer."""
 
-    def __init__(self, *args, query_length: int = 32, doc_length: int = 512, **kwargs):
+    def __init__(self, *args, query_length: int | None = 32, doc_length: int | None = 512, **kwargs):
         """Initializes the tokenizer.
 
         Args:
-            query_length (int, optional): Maximum number of tokens per query. Defaults to 32.
-            doc_length (int, optional): Maximum number of tokens per document. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
         """
         super().__init__(*args, query_length=query_length, doc_length=doc_length, **kwargs)
         self.query_length = query_length

--- a/lightning_ir/bi_encoder/bi_encoder_config.py
+++ b/lightning_ir/bi_encoder/bi_encoder_config.py
@@ -17,8 +17,8 @@ class BiEncoderConfig(LightningIRConfig):
 
     def __init__(
         self,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         similarity_function: Literal["cosine", "dot"] = "dot",
         normalization: Literal["l2"] | None = None,
         sparsification: Literal["relu", "relu_log", "relu_2xlog"] | None = None,
@@ -30,8 +30,8 @@ class BiEncoderConfig(LightningIRConfig):
         embeddings before computing the similarity score.
 
         Args:
-            query_length (int): Maximum query length. Defaults to 32.
-            doc_length (int): Maximum document length. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             similarity_function (Literal['cosine', 'dot']): Similarity function to compute scores between query and
                 document embeddings. Defaults to "dot".
             normalization (Literal['l2'] | None): Whether to normalize query and document embeddings. Defaults to None.
@@ -69,8 +69,8 @@ class SingleVectorBiEncoderConfig(BiEncoderConfig):
 
     def __init__(
         self,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         similarity_function: Literal["cosine", "dot"] = "dot",
         normalization: Literal["l2"] | None = None,
         sparsification: Literal["relu", "relu_log", "relu_2xlog"] | None = None,
@@ -83,8 +83,8 @@ class SingleVectorBiEncoderConfig(BiEncoderConfig):
         representations of queries and documents into a single vector before computing a similarity score.
 
         Args:
-            query_length (int): Maximum query length. Defaults to 32.
-            doc_length (int): Maximum document length. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             similarity_function (Literal['cosine', 'dot']): Similarity function to compute scores between query and
                 document embeddings. Defaults to "dot".
             normalization (Literal['l2'] | None): Whether to normalize query and document embeddings. Defaults to None.
@@ -118,8 +118,8 @@ class MultiVectorBiEncoderConfig(BiEncoderConfig):
 
     def __init__(
         self,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         similarity_function: Literal["cosine", "dot"] = "dot",
         normalization: Literal["l2"] | None = None,
         sparsification: None | Literal["relu", "relu_log", "relu_2xlog"] = None,
@@ -135,8 +135,8 @@ class MultiVectorBiEncoderConfig(BiEncoderConfig):
         masked out during scoring.
 
         Args:
-            query_length (int): Maximum query length. Defaults to 32.
-            doc_length (int): Maximum document length. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             similarity_function (Literal['cosine', 'dot']): Similarity function to compute scores between query and
                 document embeddings. Defaults to "dot".
             normalization (Literal['l2'] | None): Whether to normalize query and document embeddings. Defaults to None.

--- a/lightning_ir/bi_encoder/bi_encoder_module.py
+++ b/lightning_ir/bi_encoder/bi_encoder_module.py
@@ -249,7 +249,7 @@ class BiEncoderModule(LightningIRModule):
         Args:
             batch (TrainBatch | IndexBatch | SearchBatch | RankBatch): Batch of validation or testing data.
             batch_idx (int): Index of the batch.
-            dataloader_idx (int, optional): Index of the dataloader. Defaults to 0.
+            dataloader_idx (int | None): Index of the dataloader. Defaults to 0.
         Returns:
             BiEncoderOutput: Output of the model.
         """

--- a/lightning_ir/callbacks/callbacks.py
+++ b/lightning_ir/callbacks/callbacks.py
@@ -223,7 +223,7 @@ class IndexCallback(Callback, _GatherMixin, _IndexDirMixin, _OverwriteMixin):
             pl_module (BiEncoderModule): LightningIR bi-encoder module.
             batch (Any): Batch of input data.
             batch_idx (int): Index of batch in the current dataset.
-            dataloader_idx (int, optional): Index of the dataloader. Defaults to 0.
+            dataloader_idx (int | None): Index of the dataloader. Defaults to 0.
         """
         if batch_idx == 0:
             self.indexer = self._get_indexer(pl_module, dataloader_idx)
@@ -246,7 +246,7 @@ class IndexCallback(Callback, _GatherMixin, _IndexDirMixin, _OverwriteMixin):
             outputs (BiEncoderOutput): Encoded documents.
             batch (Any): Batch of input data.
             batch_idx (int): Index of batch in the current dataset.
-            dataloader_idx (int, optional): Index of the dataloader. Defaults to 0.
+            dataloader_idx (int | None): Index of the dataloader. Defaults to 0.
         """
         batch = self._gather(pl_module, batch)
         outputs = self._gather(pl_module, outputs)
@@ -383,7 +383,7 @@ class RankCallback(Callback, _GatherMixin, _OverwriteMixin):
             outputs (LightningIROutput): Scored query documents pairs.
             batch (Any): Batch of input data.
             batch_idx (int): Index of batch in the current dataset.
-            dataloader_idx (int, optional): Index of the dataloader. Defaults to 0.
+            dataloader_idx (int | None): Index of the dataloader. Defaults to 0.
         Raises:
             ValueError: If the batch does not have query_ids.
         """
@@ -503,7 +503,7 @@ class SearchCallback(RankCallback, _IndexDirMixin):
             pl_module (BiEncoderModule): LightningIR bi-encoder module.
             batch (Any): Batch of input data.
             batch_idx (int): Index of the batch in the dataset.
-            dataloader_idx (int, optional): Index of the dataloader. Defaults to 0.
+            dataloader_idx (int | None): Index of the dataloader. Defaults to 0.
         """
         if batch_idx == 0:
             self.searcher = self._get_searcher(trainer, pl_module, dataloader_idx)

--- a/lightning_ir/cross_encoder/cross_encoder_config.py
+++ b/lightning_ir/cross_encoder/cross_encoder_config.py
@@ -15,8 +15,8 @@ class CrossEncoderConfig(LightningIRConfig):
 
     def __init__(
         self,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         pooling_strategy: Literal["first", "mean", "max", "sum"] = "first",
         linear_bias: bool = False,
         **kwargs
@@ -24,8 +24,8 @@ class CrossEncoderConfig(LightningIRConfig):
         """Configuration class for a cross-encoder model
 
         Args:
-            query_length (int): Maximum query length. Defaults to 32.
-            doc_length (int): Maximum document length. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             pooling_strategy (Literal['first', 'mean', 'max', 'sum']): Pooling strategy to aggregate the
                 contextualized embeddings into a single vector for computing a relevance score. Defaults to "first".
             linear_bias (bool): Whether to use a bias in the prediction linear layer. Defaults to False.

--- a/lightning_ir/models/bi_encoders/coil.py
+++ b/lightning_ir/models/bi_encoders/coil.py
@@ -48,8 +48,8 @@ class CoilConfig(MultiVectorBiEncoderConfig):
 
     def __init__(
         self,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         similarity_function: Literal["cosine", "dot"] = "dot",
         add_marker_tokens: bool = False,
         token_embedding_dim: int = 32,
@@ -61,14 +61,14 @@ class CoilConfig(MultiVectorBiEncoderConfig):
         similarity ...
 
         Args:
-            query_length (int, optional): Maximum query length in number of tokens. Defaults to 32.
-            doc_length (int, optional): Maximum document length in number of tokens. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             similarity_function (Literal["cosine", "dot"]): Similarity function to compute scores between query and
                 document embeddings. Defaults to "dot".
             add_marker_tokens (bool): Whether to add extra marker tokens [Q] / [D] to queries / documents.
                 Defaults to False.
-            token_embedding_dim (int, optional): The output embedding dimension for tokens. Defaults to 32.
-            cls_embedding_dim (int, optional): The output embedding dimension for the [CLS] token. Defaults to 768.
+            token_embedding_dim (int | None): The output embedding dimension for tokens. Defaults to 32.
+            cls_embedding_dim (int | None): The output embedding dimension for the [CLS] token. Defaults to 768.
             projection (Literal["linear", "linear_no_bias"], optional): Whether and how to project the embeddings.
                 Defaults to "linear".
         """
@@ -193,8 +193,8 @@ class UniCoilConfig(SingleVectorBiEncoderConfig):
 
     def __init__(
         self,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         similarity_function: Literal["cosine", "dot"] = "dot",
         projection: Literal["linear", "linear_no_bias"] = "linear",
         **kwargs,
@@ -203,8 +203,8 @@ class UniCoilConfig(SingleVectorBiEncoderConfig):
         similarity of token embeddings between query and document.
 
         Args:
-            query_length (int, optional): Maximum query length in number of tokens. Defaults to 32.
-            doc_length (int, optional): Maximum document length in number of tokens. Defaults to 512.
+            query_length (int | None): Maximum query length in number of tokens. Defaults to 32.
+            doc_length (int | None): Maximum document length in number of tokens. Defaults to 512.
             similarity_function (Literal["cosine", "dot"]): Similarity function to compute scores between query and
                 document embeddings. Defaults to "dot".
             projection (Literal["linear", "linear_no_bias"], optional): Whether and how to project the embeddings.

--- a/lightning_ir/models/bi_encoders/col.py
+++ b/lightning_ir/models/bi_encoders/col.py
@@ -20,8 +20,8 @@ class ColConfig(MultiVectorBiEncoderConfig):
 
     def __init__(
         self,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         similarity_function: Literal["cosine", "dot"] = "dot",
         normalization: Literal["l2"] | None = None,
         add_marker_tokens: bool = False,
@@ -44,8 +44,8 @@ class ColConfig(MultiVectorBiEncoderConfig):
         be ignored during scoring.
 
         Args:
-            query_length (int): Maximum query length in number of tokens. Defaults to 32.
-            doc_length (int): Maximum document length in number of tokens. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             similarity_function (Literal["cosine", "dot"]): Similarity function to compute scores between query and
                 document embeddings. Defaults to "dot".
             normalization (Literal['l2'] | None): Whether to normalize query and document embeddings. Defaults to None.
@@ -159,8 +159,8 @@ class ColTokenizer(BiEncoderTokenizer):
     def __init__(
         self,
         *args,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         add_marker_tokens: bool = False,
         query_expansion: bool = False,
         attend_to_query_expanded_tokens: bool = False,
@@ -172,8 +172,8 @@ class ColTokenizer(BiEncoderTokenizer):
         to encoded input sequences and expands queries and documents with mask tokens.
 
         Args:
-            query_length (int): Maximum query length in number of tokens. Defaults to 32.
-            doc_length (int): Maximum document length in number of tokens. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             add_marker_tokens (bool): Whether to add extra marker tokens [Q] / [D] to queries / documents.
                 Defaults to False.
             query_expansion (bool): Whether to expand queries with mask tokens. Defaults to False.

--- a/lightning_ir/models/bi_encoders/dpr.py
+++ b/lightning_ir/models/bi_encoders/dpr.py
@@ -21,8 +21,8 @@ class DprConfig(SingleVectorBiEncoderConfig):
 
     def __init__(
         self,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         similarity_function: Literal["cosine", "dot"] = "dot",
         normalize: bool = False,
         sparsification: Literal["relu", "relu_log", "relu_2xlog"] | None = None,
@@ -38,8 +38,8 @@ class DprConfig(SingleVectorBiEncoderConfig):
         Optionally, the pooled embeddings can be projected using a linear layer.
 
         Args:
-            query_length (int): Maximum query length. Defaults to 32.
-            doc_length (int): Maximum document length. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             similarity_function (Literal["cosine", "dot"]): Similarity function to compute scores between query and
                 document embeddings. Defaults to "dot".
             normalize (bool): Whether to normalize the embeddings. Defaults to False.

--- a/lightning_ir/models/bi_encoders/mvr.py
+++ b/lightning_ir/models/bi_encoders/mvr.py
@@ -11,11 +11,7 @@ from transformers import BatchEncoding
 
 from lightning_ir.bi_encoder.bi_encoder_model import BiEncoderEmbedding
 
-from ...bi_encoder import (
-    BiEncoderTokenizer,
-    MultiVectorBiEncoderConfig,
-    MultiVectorBiEncoderModel,
-)
+from ...bi_encoder import BiEncoderTokenizer, MultiVectorBiEncoderConfig, MultiVectorBiEncoderModel
 
 
 class MvrConfig(MultiVectorBiEncoderConfig):
@@ -26,8 +22,8 @@ class MvrConfig(MultiVectorBiEncoderConfig):
 
     def __init__(
         self,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         similarity_function: Literal["cosine", "dot"] = "dot",
         normalization: Literal["l2"] | None = None,
         add_marker_tokens: bool = False,
@@ -43,8 +39,8 @@ class MvrConfig(MultiVectorBiEncoderConfig):
         between the query vector and the viewer token vectors is used to compute the relevance score.
 
         Args:
-            query_length (int): Maximum query length. Defaults to 32.
-            doc_length (int): Maximum document length. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             similarity_function (Literal['cosine', 'dot']): Similarity function to compute scores between query and
                 document embeddings. Defaults to "dot".
             normalization (Literal['l2'] | None): Whether to normalize query and document embeddings. Defaults to None.
@@ -142,8 +138,8 @@ class MvrTokenizer(BiEncoderTokenizer):
     def __init__(
         self,
         *args,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         add_marker_tokens: bool = False,
         num_viewer_tokens: int = 8,
         **kwargs,

--- a/lightning_ir/models/bi_encoders/splade.py
+++ b/lightning_ir/models/bi_encoders/splade.py
@@ -32,8 +32,8 @@ class SpladeConfig(SingleVectorBiEncoderConfig):
 
     def __init__(
         self,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         similarity_function: Literal["cosine", "dot"] = "dot",
         sparsification: Literal["relu", "relu_log", "relu_2xlog"] | None = "relu_log",
         query_pooling_strategy: Literal["first", "mean", "max", "sum"] = "max",
@@ -50,8 +50,8 @@ class SpladeConfig(SingleVectorBiEncoderConfig):
         embedding for the query and document.
 
         Args:
-            query_length (int): Maximum query length. Defaults to 32.
-            doc_length (int): Maximum document length. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             similarity_function (Literal["cosine", "dot"]): Similarity function to compute scores between query and
                 document embeddings. Defaults to "dot".
             sparsification (Literal['relu', 'relu_log', 'relu_2xlog'] | None): Whether and which sparsification
@@ -239,8 +239,8 @@ class SpladeTokenizer(BiEncoderTokenizer):
     def __init__(
         self,
         *args,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         add_marker_tokens: bool = False,
         query_weighting: Literal["contextualized", "static"] = "contextualized",
         doc_weighting: Literal["contextualized", "static"] = "contextualized",
@@ -253,8 +253,8 @@ class SpladeTokenizer(BiEncoderTokenizer):
         marker tokens to encoded input sequences.
 
         Args:
-            query_length (int): Maximum query length in number of tokens. Defaults to 32.
-            doc_length (int): Maximum document length in number of tokens. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             add_marker_tokens (bool): Whether to add extra marker tokens [Q] / [D] to queries / documents.
                 Defaults to False.
             query_expansion (bool): Whether to expand queries with mask tokens. Defaults to False.

--- a/lightning_ir/models/cross_encoders/mono.py
+++ b/lightning_ir/models/cross_encoders/mono.py
@@ -29,8 +29,8 @@ class MonoConfig(CrossEncoderConfig):
 
     def __init__(
         self,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         pooling_strategy: Literal["first", "mean", "max", "sum", "bert_pool"] = "first",
         linear_bias: bool = False,
         scoring_strategy: Literal["mono", "rank"] = "rank",
@@ -40,8 +40,8 @@ class MonoConfig(CrossEncoderConfig):
         """Initialize the configuration for mono cross-encoder models.
 
         Args:
-            query_length (int): Maximum query length. Defaults to 32.
-            doc_length (int): Maximum document length. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             pooling_strategy (Literal["first", "mean", "max", "sum", "bert_pool"]): Pooling strategy for the
                 embeddings. Defaults to "first".
             linear_bias (bool): Whether to use bias in the final linear layer. Defaults to False.

--- a/lightning_ir/models/cross_encoders/set_encoder.py
+++ b/lightning_ir/models/cross_encoders/set_encoder.py
@@ -226,16 +226,16 @@ class SetEncoderTokenizer(CrossEncoderTokenizer):
     def __init__(
         self,
         *args,
-        query_length: int = 32,
-        doc_length: int = 512,
+        query_length: int | None = 32,
+        doc_length: int | None = 512,
         add_extra_token: bool = False,
         **kwargs,
     ):
         """Initializes a SetEncoder tokenizer.
 
         Args:
-            query_length (int): Maximum query length. Defaults to 32.
-            doc_length (int): Maximum document length. Defaults to 512.
+            query_length (int | None): Maximum number of tokens per query. If None does not truncate. Defaults to 32.
+            doc_length (int | None): Maximum number of tokens per document. If None does not truncate. Defaults to 512.
             add_extra_token (bool): Whether to add an extra interaction token. Defaults to False.
         """
         super().__init__(

--- a/lightning_ir/models/register_external_models.py
+++ b/lightning_ir/models/register_external_models.py
@@ -76,10 +76,6 @@ def _map_opensearch_splade_weights(model: LightningIRModel) -> LightningIRModel:
     return model
 
 
-MONO_T5_PATTERN = "Query: {query} Document: {doc} Relevant:"
-RANK_T5_PATTERN = "Query: {query} Document: {doc}"
-
-
 def _register_external_models():
     CHECKPOINT_MAPPING.update(
         {
@@ -125,17 +121,19 @@ def _register_external_models():
             "sentence-transformers/msmarco-MiniLM-L-6-v3": DprConfig(
                 projection=None, query_pooling_strategy="mean", doc_pooling_strategy="mean"
             ),
-            "castorini/monot5-base-msmarco-10k": MonoConfig(scoring_strategy="mono", tokenizer_pattern=MONO_T5_PATTERN),
-            "castorini/monot5-base-msmarco": MonoConfig(scoring_strategy="mono", tokenizer_pattern=MONO_T5_PATTERN),
-            "castorini/monot5-large-msmarco-10k": MonoConfig(
-                scoring_strategy="mono", tokenizer_pattern=MONO_T5_PATTERN
+            "castorini/monot5-base-msmarco-10k": MonoConfig(
+                scoring_strategy="mono", query_length=None, doc_length=None
             ),
-            "castorini/monot5-large-msmarco": MonoConfig(scoring_strategy="mono", tokenizer_pattern=MONO_T5_PATTERN),
-            "castorini/monot5-3b-msmarco-10k": MonoConfig(scoring_strategy="mono", tokenizer_pattern=MONO_T5_PATTERN),
-            "castorini/monot5-3b-msmarco": MonoConfig(scoring_strategy="mono", tokenizer_pattern=MONO_T5_PATTERN),
-            "Soyoung97/RankT5-base": MonoConfig(scoring_strategy="rank", tokenizer_pattern=RANK_T5_PATTERN),
-            "Soyoung97/RankT5-large": MonoConfig(scoring_strategy="rank", tokenizer_pattern=RANK_T5_PATTERN),
-            "Soyoung97/RankT5-3b": MonoConfig(scoring_strategy="rank", tokenizer_pattern=RANK_T5_PATTERN),
+            "castorini/monot5-base-msmarco": MonoConfig(scoring_strategy="mono", query_length=None, doc_length=None),
+            "castorini/monot5-large-msmarco-10k": MonoConfig(
+                scoring_strategy="mono", query_length=None, doc_length=None
+            ),
+            "castorini/monot5-large-msmarco": MonoConfig(scoring_strategy="mono", query_length=None, doc_length=None),
+            "castorini/monot5-3b-msmarco-10k": MonoConfig(scoring_strategy="mono", query_length=None, doc_length=None),
+            "castorini/monot5-3b-msmarco": MonoConfig(scoring_strategy="mono", query_length=None, doc_length=None),
+            "Soyoung97/RankT5-base": MonoConfig(scoring_strategy="rank", query_length=None, doc_length=None),
+            "Soyoung97/RankT5-large": MonoConfig(scoring_strategy="rank", query_length=None, doc_length=None),
+            "Soyoung97/RankT5-3b": MonoConfig(scoring_strategy="rank", query_length=None, doc_length=None),
             "castorini/monobert-large-msmarco-finetune-only": MonoConfig(
                 scoring_strategy="mono", linear_bias=True, pooling_strategy="bert_pool"
             ),

--- a/lightning_ir/schedulers/schedulers.py
+++ b/lightning_ir/schedulers/schedulers.py
@@ -64,7 +64,7 @@ class LinearSchedulerWithLinearWarmup(LambdaWarmupScheduler):
             num_warmup_steps (int): Number of warmup steps.
             num_training_steps (int): Number of training steps.
             final_value (float, optional): Final value that should be reached at the end of decay. Defaults to 0.0.
-            num_delay_steps (int, optional): Number of steps to delay warmup / decay. Defaults to 0.
+            num_delay_steps (int | None): Number of steps to delay warmup / decay. Defaults to 0.
         """
         self.num_training_steps = num_training_steps
         self.final_value = final_value

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -76,6 +76,7 @@ def test_seralize_deserialize(module: LightningIRModule, tmp_path: Path):
         AutoModel.from_pretrained(save_dir),
     ]
     for new_model in new_models:
+        assert new_model.__class__.__name__ == model.__class__.__name__
         for key, value in model.config.__dict__.items():
             if key in (
                 "torch_dtype",

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -22,6 +22,7 @@ def test_serialize_deserialize(
         Tokenizer.__bases__[0].from_pretrained(save_dir),
     ]
     for new_tokenizer in new_tokenizers:
+        assert new_tokenizer.__class__.__name__ == tokenizer.__class__.__name__
         for key in tokenizer_kwargs:
             assert getattr(tokenizer, key) == getattr(new_tokenizer, key)
 


### PR DESCRIPTION
This PR does three main things:
- Makes query and doc lengths optional (no truncation)
- Uses template processing for tokenization patterns for monoT5 and RankT5 models
- Improves the auto loading of cross-encoder tokenizers