### PR TITLE
Enhance tokenizer compatibility with transformers v4 and v5

### DIFF
--- a/lightning_ir/base/class_factory.py
+++ b/lightning_ir/base/class_factory.py
@@ -27,20 +27,6 @@ if TYPE_CHECKING:
     from . import LightningIRConfig, LightningIRModel, LightningIRTokenizer
 
 
-def _get_tokenizer_tuple(
-    config_class: type[PretrainedConfig],
-) -> tuple[type[PreTrainedTokenizerBase] | None, type[PreTrainedTokenizerBase] | None]:
-    """Normalize TOKENIZER_MAPPING result for compatibility with transformers v4 and v5.
-
-    transformers v4 returns a (slow, fast) tuple; transformers v5 returns a single class.
-    """
-    result = TOKENIZER_MAPPING[config_class]
-    if isinstance(result, tuple):
-        return result
-    # transformers v5: single unified tokenizer class — expose as both slow and fast
-    return (result, result)
-
-
 def _get_model_class(config: PretrainedConfig | type[PretrainedConfig]) -> type[PreTrainedModel]:
     # https://github.com/huggingface/transformers/blob/356b3cd71d7bfb51c88fea3e8a0c054f3a457ab9/src/transformers/models/auto/auto_factory.py#L387
     if isinstance(config, type):
@@ -296,9 +282,7 @@ class LightningIRTokenizerClassFactory(LightningIRClassFactory):
             if backbone_tokenizer_class is not None:
                 config_class = backbone_tokenizer_class.removesuffix("Fast").replace("Tokenizer", "Config")
                 for module_name, tokenizers in TOKENIZER_MAPPING_NAMES.items():
-                    # v4: tokenizers is a (slow, fast) tuple; v5: tokenizers is a single string
-                    tokenizer_names = tokenizers if isinstance(tokenizers, (list, tuple)) else (tokenizers,)
-                    if backbone_tokenizer_class in tokenizer_names:
+                    if backbone_tokenizer_class in tokenizers:
                         module_name = model_type_to_module_name(module_name)
                         module = importlib.import_module(f".{module_name}", "transformers.models")
                         if hasattr(module, backbone_tokenizer_class) and hasattr(module, config_class):
@@ -321,7 +305,7 @@ class LightningIRTokenizerClassFactory(LightningIRClassFactory):
             ValueError: If no slow tokenizer is found when `use_fast` is False.
         """
         backbone_config = self.get_backbone_config(model_name_or_path)
-        BackboneTokenizers = _get_tokenizer_tuple(type(backbone_config))
+        BackboneTokenizers = TOKENIZER_MAPPING[type(backbone_config)]
         DerivedLightningIRTokenizers = self.from_backbone_classes(BackboneTokenizers, type(backbone_config))
         if use_fast:
             DerivedLightningIRTokenizer = DerivedLightningIRTokenizers[1]
@@ -370,7 +354,7 @@ https://huggingface.co/transformers/main_classes/tokenizer.html#transformers.Pre
         """
         if hasattr(BackboneClass, "config_class"):
             return BackboneClass
-        LightningIRTokenizerMixin = _get_tokenizer_tuple(self.MixinConfig)[0]
+        LightningIRTokenizerMixin = TOKENIZER_MAPPING[self.MixinConfig][0]
 
         DerivedLightningIRTokenizer = type(
             f"{self.cc_lir_model_type(LightningIRTokenizerMixin.config_class)}{BackboneClass.__name__}",

--- a/lightning_ir/base/class_factory.py
+++ b/lightning_ir/base/class_factory.py
@@ -407,7 +407,10 @@ https://huggingface.co/transformers/main_classes/tokenizer.html#transformers.Pre
             return BackboneClass
         _tokenizer_mapping = TOKENIZER_MAPPING[self.MixinConfig]
         # transformers v4 returns (slow, fast) tuple; v5 returns a single class
-        LightningIRTokenizerMixin = _tokenizer_mapping[0] if isinstance(_tokenizer_mapping, (tuple, list)) else _tokenizer_mapping
+        if isinstance(_tokenizer_mapping, (tuple, list)):
+            LightningIRTokenizerMixin = _tokenizer_mapping[0]
+        else:
+            LightningIRTokenizerMixin = _tokenizer_mapping
 
         DerivedLightningIRTokenizer = type(
             f"{self.cc_lir_model_type(LightningIRTokenizerMixin.config_class)}{BackboneClass.__name__}",

--- a/lightning_ir/base/config.py
+++ b/lightning_ir/base/config.py
@@ -108,7 +108,10 @@ https://huggingface.co/docs/transformers/en/main_classes/configuration#transform
         Returns:
             LightningIRConfig: Derived LightningIRConfig instance.
         """
-        if (cls is LightningIRConfig or all(issubclass(base, LightningIRConfig) for base in cls.__bases__)) and "backbone_model_type" in config_dict:
+        if (
+            (cls is LightningIRConfig or all(issubclass(base, LightningIRConfig) for base in cls.__bases__))
+            and "backbone_model_type" in config_dict
+        ):
             from transformers import CONFIG_MAPPING
 
             backbone_model_type = config_dict["backbone_model_type"]

--- a/lightning_ir/base/config.py
+++ b/lightning_ir/base/config.py
@@ -109,9 +109,8 @@ https://huggingface.co/docs/transformers/en/main_classes/configuration#transform
             LightningIRConfig: Derived LightningIRConfig instance.
         """
         if (
-            (cls is LightningIRConfig or all(issubclass(base, LightningIRConfig) for base in cls.__bases__))
-            and "backbone_model_type" in config_dict
-        ):
+            cls is LightningIRConfig or all(issubclass(base, LightningIRConfig) for base in cls.__bases__)
+        ) and "backbone_model_type" in config_dict:
             from transformers import CONFIG_MAPPING
 
             backbone_model_type = config_dict["backbone_model_type"]

--- a/lightning_ir/base/tokenizer.py
+++ b/lightning_ir/base/tokenizer.py
@@ -9,9 +9,9 @@ from collections.abc import Sequence
 from os import PathLike
 from typing import Self
 
-from transformers import TOKENIZER_MAPPING, BatchEncoding, PreTrainedTokenizerBase
+from transformers import BatchEncoding, PreTrainedTokenizerBase
 
-from .class_factory import LightningIRTokenizerClassFactory
+from .class_factory import LightningIRTokenizerClassFactory, _get_tokenizer_tuple
 from .config import LightningIRConfig
 from .external_model_hub import CHECKPOINT_MAPPING
 
@@ -99,7 +99,7 @@ https://huggingface.co/docs/transformers/main_classes/tokenizer.html#transformer
                     raise ValueError("Pass a config to `from_pretrained`.")
             ConfigClass = getattr(ConfigClass, "mixin_config", ConfigClass)
             backbone_config = LightningIRTokenizerClassFactory.get_backbone_config(model_name_or_path)
-            BackboneTokenizers = TOKENIZER_MAPPING[type(backbone_config)]
+            BackboneTokenizers = _get_tokenizer_tuple(type(backbone_config))
             if kwargs.get("use_fast", True):
                 BackboneTokenizer = BackboneTokenizers[1]
             else:

--- a/lightning_ir/base/tokenizer.py
+++ b/lightning_ir/base/tokenizer.py
@@ -9,9 +9,9 @@ from collections.abc import Sequence
 from os import PathLike
 from typing import Self
 
-from transformers import BatchEncoding, PreTrainedTokenizerBase
+from transformers import TOKENIZER_MAPPING, BatchEncoding, PreTrainedTokenizerBase
 
-from .class_factory import LightningIRTokenizerClassFactory, _get_tokenizer_tuple
+from .class_factory import LightningIRTokenizerClassFactory
 from .config import LightningIRConfig
 from .external_model_hub import CHECKPOINT_MAPPING
 
@@ -99,7 +99,7 @@ https://huggingface.co/docs/transformers/main_classes/tokenizer.html#transformer
                     raise ValueError("Pass a config to `from_pretrained`.")
             ConfigClass = getattr(ConfigClass, "mixin_config", ConfigClass)
             backbone_config = LightningIRTokenizerClassFactory.get_backbone_config(model_name_or_path)
-            BackboneTokenizers = _get_tokenizer_tuple(type(backbone_config))
+            BackboneTokenizers = TOKENIZER_MAPPING[type(backbone_config)]
             if kwargs.get("use_fast", True):
                 BackboneTokenizer = BackboneTokenizers[1]
             else:

--- a/lightning_ir/models/bi_encoders/splade.py
+++ b/lightning_ir/models/bi_encoders/splade.py
@@ -114,7 +114,10 @@ class SpladeModel(SingleVectorBiEncoderModel):
         # grab language modeling head based on backbone model type
         layer_cls = MODEL_TYPE_TO_LM_HEAD[config.backbone_model_type or config.model_type]
         self.projection = layer_cls(config)
-        tied_weight_keys = (getattr(self, "_tied_weights_keys", []) or []) + ["projection.decoder.weight"]
+        tied_weight_keys = getattr(self, "_tied_weights_keys", {}) or {}
+        if not isinstance(tied_weight_keys, dict):
+            tied_weight_keys = {key: None for key in tied_weight_keys}
+        tied_weight_keys["projection.decoder.weight"] = None
         self._tied_weights_keys = tied_weight_keys
         self.query_weights = None
         if config.query_weighting == "static":

--- a/lightning_ir/models/bi_encoders/splade.py
+++ b/lightning_ir/models/bi_encoders/splade.py
@@ -117,7 +117,10 @@ class SpladeModel(SingleVectorBiEncoderModel):
         existing_tied = getattr(self, "_tied_weights_keys", None) or {}
         if isinstance(existing_tied, dict):
             # transformers v5: _tied_weights_keys is a dict {tied_key: source_key}
-            tied_weight_keys: dict | list = {**existing_tied, "projection.decoder.weight": "embeddings.word_embeddings.weight", }
+            tied_weight_keys: dict | list = {
+                **existing_tied,
+                "projection.decoder.weight": "embeddings.word_embeddings.weight",
+            }
         else:
             # transformers v4: _tied_weights_keys is a list of tied key names
             tied_weight_keys = list(existing_tied) + ["projection.decoder.weight"]

--- a/lightning_ir/models/bi_encoders/splade.py
+++ b/lightning_ir/models/bi_encoders/splade.py
@@ -114,10 +114,7 @@ class SpladeModel(SingleVectorBiEncoderModel):
         # grab language modeling head based on backbone model type
         layer_cls = MODEL_TYPE_TO_LM_HEAD[config.backbone_model_type or config.model_type]
         self.projection = layer_cls(config)
-        tied_weight_keys = getattr(self, "_tied_weights_keys", {}) or {}
-        if not isinstance(tied_weight_keys, dict):
-            tied_weight_keys = {key: None for key in tied_weight_keys}
-        tied_weight_keys["projection.decoder.weight"] = None
+        tied_weight_keys = (getattr(self, "_tied_weights_keys", []) or []) + ["projection.decoder.weight"]
         self._tied_weights_keys = tied_weight_keys
         self.query_weights = None
         if config.query_weighting == "static":

--- a/lightning_ir/models/cross_encoders/set_encoder.py
+++ b/lightning_ir/models/cross_encoders/set_encoder.py
@@ -181,13 +181,6 @@ class SetEncoderModel(MonoModel):
             .transpose(1, 2)
         )
 
-        if attention_mask is not None and num_docs is not None and attention_mask.shape[-1] != key.shape[-2]:
-            other_doc_attention_mask = _self._build_other_doc_attention_mask(num_docs, hidden_states.device)
-            other_doc_attention_mask = other_doc_attention_mask[:, None, None, :].expand(
-                -1, 1, query.shape[-2], -1
-            )
-            attention_mask = torch.cat([attention_mask, other_doc_attention_mask.to(attention_mask)], dim=-1)
-
         context = torch.nn.functional.scaled_dot_product_attention(
             query,
             key,
@@ -199,7 +192,7 @@ class SetEncoderModel(MonoModel):
         context = context.permute(0, 2, 1, 3).contiguous()
         new_context_shape = context.size()[:-2] + (self.all_head_size,)
         context = context.view(new_context_shape)
-        return (context, None)
+        return (context,)
 
     def cat_other_doc_hidden_states(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "transformers[torch]>=4.50.0",
+    "transformers[torch]>=4.50.0,<5.0.0",
     "datasets>=3.0.0",
     "ir_datasets",
     "ir-measures",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,7 @@ def test_serialize_deserialize(module: LightningIRModule, tmp_path: Path):
                 "transformers_version",
                 "_attn_implementation_autoset",
                 "_attn_implementation_internal",
+                "_experts_implementation_internal",
             ):
                 continue
             assert getattr(new_config, key) == value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,7 +26,6 @@ def test_serialize_deserialize(module: LightningIRModule, tmp_path: Path):
                 "transformers_version",
                 "_attn_implementation_autoset",
                 "_attn_implementation_internal",
-                "_experts_implementation_internal",
             ):
                 continue
             assert getattr(new_config, key) == value

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -92,6 +92,8 @@ def test_seralize_deserialize(module: LightningIRModule, tmp_path: Path):
                 "_commit_hash",
                 "transformers_version",
                 "_attn_implementation_autoset",
+                "_attn_implementation_internal",
+                "_experts_implementation_internal",
             ):
                 continue
             assert getattr(new_model.config, key) == value

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -92,8 +92,6 @@ def test_seralize_deserialize(module: LightningIRModule, tmp_path: Path):
                 "_commit_hash",
                 "transformers_version",
                 "_attn_implementation_autoset",
-                "_attn_implementation_internal",
-                "_experts_implementation_internal",
             ):
                 continue
             assert getattr(new_model.config, key) == value


### PR DESCRIPTION
Improve compatibility of the tokenizer with both transformers v4 and v5 by normalizing the TOKENIZER_MAPPING results and adjusting related functions accordingly.