### PR TITLE
Make LightningIR compatible with transformers v5

### DIFF
--- a/lightning_ir/base/class_factory.py
+++ b/lightning_ir/base/class_factory.py
@@ -16,6 +16,7 @@ from transformers import (
     CONFIG_MAPPING,
     MODEL_MAPPING,
     TOKENIZER_MAPPING,
+    AutoTokenizer,
     PretrainedConfig,
     PreTrainedModel,
     PreTrainedTokenizerBase,
@@ -154,6 +155,9 @@ class LightningIRClassFactory(ABC):
         ...
 
 
+_CONFIG_CLASS_CACHE: dict[tuple[str, str], type] = {}
+
+
 class LightningIRConfigClassFactory(LightningIRClassFactory):
     """Class factory for creating derived LightningIRConfig classes from HuggingFace configuration classes."""
 
@@ -183,18 +187,28 @@ https://huggingface.co/docs/transformers/main_classes/configuration#transformers
         """
         if getattr(BackboneClass, "backbone_model_type", None) is not None:
             return BackboneClass
+
+        cache_key = (self.MixinConfig.model_type, BackboneClass.__name__)
+        if cache_key in _CONFIG_CLASS_CACHE:
+            return _CONFIG_CLASS_CACHE[cache_key]
+
         LightningIRConfigMixin: type[LightningIRConfig] = CONFIG_MAPPING[self.MixinConfig.model_type]
 
         DerivedLightningIRConfig = type(
             f"{self.cc_lir_model_type(LightningIRConfigMixin)}{BackboneClass.__name__}",
             (LightningIRConfigMixin, BackboneClass),
             {
+                "__init__": LightningIRConfigMixin.__init__,
                 "model_type": self.MixinConfig.model_type,
                 "backbone_model_type": BackboneClass.model_type,
                 "mixin_config": self.MixinConfig,
             },
         )
+        _CONFIG_CLASS_CACHE[cache_key] = DerivedLightningIRConfig
         return DerivedLightningIRConfig
+
+
+_MODEL_CLASS_CACHE: dict[tuple[str, str], type] = {}
 
 
 class LightningIRModelClassFactory(LightningIRClassFactory):
@@ -237,6 +251,10 @@ https://huggingface.co/transformers/main_classes/model#transformers.PreTrainedMo
                 f"Model {BackboneClass} is not a valid backbone model because it is missing a `config_class`."
             )
 
+        cache_key = (self.MixinConfig.model_type, BackboneClass.__name__)
+        if cache_key in _MODEL_CLASS_CACHE:
+            return _MODEL_CLASS_CACHE[cache_key]
+
         LightningIRModelMixin: type[LightningIRModel] = _get_model_class(self.MixinConfig)
 
         DerivedLightningIRConfig = LightningIRConfigClassFactory(self.MixinConfig).from_backbone_class(BackboneConfig)
@@ -246,6 +264,12 @@ https://huggingface.co/transformers/main_classes/model#transformers.PreTrainedMo
             (LightningIRModelMixin, BackboneClass),
             {"config_class": DerivedLightningIRConfig, "_backbone_forward": BackboneClass.forward},
         )
+
+        from transformers import AutoModel
+
+        AutoModel.register(DerivedLightningIRConfig, DerivedLightningIRModel, exist_ok=True)
+
+        _MODEL_CLASS_CACHE[cache_key] = DerivedLightningIRModel
         return DerivedLightningIRModel
 
 
@@ -282,7 +306,9 @@ class LightningIRTokenizerClassFactory(LightningIRClassFactory):
             if backbone_tokenizer_class is not None:
                 config_class = backbone_tokenizer_class.removesuffix("Fast").replace("Tokenizer", "Config")
                 for module_name, tokenizers in TOKENIZER_MAPPING_NAMES.items():
-                    if backbone_tokenizer_class in tokenizers:
+                    if isinstance(tokenizers, str):
+                        tokenizers = (tokenizers,)
+                    if tokenizers is not None and backbone_tokenizer_class in tokenizers:
                         module_name = model_type_to_module_name(module_name)
                         module = importlib.import_module(f".{module_name}", "transformers.models")
                         if hasattr(module, backbone_tokenizer_class) and hasattr(module, config_class):
@@ -305,7 +331,13 @@ class LightningIRTokenizerClassFactory(LightningIRClassFactory):
             ValueError: If no slow tokenizer is found when `use_fast` is False.
         """
         backbone_config = self.get_backbone_config(model_name_or_path)
-        BackboneTokenizers = TOKENIZER_MAPPING[type(backbone_config)]
+        try:
+            BackboneTokenizers = TOKENIZER_MAPPING[type(backbone_config)]
+        except KeyError:
+            BackboneTokenizer = AutoTokenizer.from_pretrained(
+                model_name_or_path, *args, use_fast=use_fast, **kwargs
+            ).__class__
+            BackboneTokenizers = (None, BackboneTokenizer) if use_fast else (BackboneTokenizer, None)
         DerivedLightningIRTokenizers = self.from_backbone_classes(BackboneTokenizers, type(backbone_config))
         if use_fast:
             DerivedLightningIRTokenizer = DerivedLightningIRTokenizers[1]
@@ -319,7 +351,13 @@ class LightningIRTokenizerClassFactory(LightningIRClassFactory):
 
     def from_backbone_classes(
         self,
-        BackboneClasses: tuple[type[PreTrainedTokenizerBase] | None, type[PreTrainedTokenizerBase] | None],
+        BackboneClasses: (
+            tuple[
+                type[PreTrainedTokenizerBase] | None,
+                type[PreTrainedTokenizerBase] | None,
+            ]
+            | type[PreTrainedTokenizerBase]
+        ),
         BackboneConfig: type[PretrainedConfig] | None = None,
     ) -> tuple[type[LightningIRTokenizer] | None, type[LightningIRTokenizer] | None]:
         """Creates derived slow and fastLightningIRTokenizers from a tuple of backbone HuggingFace tokenizer classes.
@@ -332,13 +370,17 @@ class LightningIRTokenizerClassFactory(LightningIRClassFactory):
             tuple[type[LightningIRTokenizer] | None, type[LightningIRTokenizer] | None]: Slow and fast derived
             LightningIRTokenizers.
         """
-        DerivedLightningIRTokenizers = tuple(
+        if not isinstance(BackboneClasses, tuple):
+            Derived = self.from_backbone_class(BackboneClasses)
+            return (Derived, Derived)
+
+        DerivedLightningIRTokenizers = list(
             None if BackboneClass is None else self.from_backbone_class(BackboneClass)
             for BackboneClass in BackboneClasses
         )
-        if DerivedLightningIRTokenizers[1] is not None:
+        if DerivedLightningIRTokenizers[1] is not None and DerivedLightningIRTokenizers[0] is not None:
             DerivedLightningIRTokenizers[1].slow_tokenizer_class = DerivedLightningIRTokenizers[0]
-        return DerivedLightningIRTokenizers
+        return tuple(DerivedLightningIRTokenizers)
 
     def from_backbone_class(self, BackboneClass: type[PreTrainedTokenizerBase]) -> type[LightningIRTokenizer]:
         """Creates a derived LightningIRTokenizer from a transformers.PreTrainedTokenizerBase_ backbone tokenizer. If
@@ -354,7 +396,8 @@ https://huggingface.co/transformers/main_classes/tokenizer.html#transformers.Pre
         """
         if hasattr(BackboneClass, "config_class"):
             return BackboneClass
-        LightningIRTokenizerMixin = TOKENIZER_MAPPING[self.MixinConfig][0]
+        mixin_mapping = TOKENIZER_MAPPING[self.MixinConfig]
+        LightningIRTokenizerMixin = mixin_mapping[0] if isinstance(mixin_mapping, tuple) else mixin_mapping
 
         DerivedLightningIRTokenizer = type(
             f"{self.cc_lir_model_type(LightningIRTokenizerMixin.config_class)}{BackboneClass.__name__}",

--- a/lightning_ir/base/config.py
+++ b/lightning_ir/base/config.py
@@ -28,6 +28,13 @@ if TYPE_CHECKING:
             pass
 
 
+def _drop_none_backbone_model_type(config_dict: dict[str, Any]) -> dict[str, Any]:
+    """Remove a null instance override so derived config classes keep their class-level backbone type."""
+    if config_dict.get("backbone_model_type") is None:
+        config_dict.pop("backbone_model_type", None)
+    return config_dict
+
+
 class LightningIRConfig(PretrainedConfig):
     """The configuration class to instantiate a Lightning IR model. Acts as a mixin for the
     transformers.PretrainedConfig_ class.
@@ -63,6 +70,7 @@ https://huggingface.co/transformers/main_classes/configuration.html#transformers
                 Defaults to None.
         """
         super().__init__(*args, **kwargs)
+        _drop_none_backbone_model_type(self.__dict__)
         self.query_length = query_length
         self.doc_length = doc_length
         self.use_adapter = use_adapter
@@ -91,9 +99,49 @@ https://huggingface.co/docs/transformers/en/main_classes/configuration#transform
             dict[str, Any]: Configuration dictionary.
         """
         output = super().to_dict()
-        if self.backbone_model_type is not None:
-            output["backbone_model_type"] = self.backbone_model_type
+        backbone_model_type = self.get_backbone_model_type()
+        if backbone_model_type is not None:
+            output["backbone_model_type"] = backbone_model_type
         return output
+
+    def get_backbone_model_type(self) -> str | None:
+        """Returns the backbone model type if it can be inferred from the config class hierarchy."""
+        backbone_model_type = self.__dict__.get("backbone_model_type", None)
+        if backbone_model_type is not None:
+            return backbone_model_type
+
+        backbone_model_type = getattr(type(self), "backbone_model_type", None)
+        if backbone_model_type is not None:
+            return backbone_model_type
+
+        for base in type(self).__mro__[1:]:
+            module_name = getattr(base, "__module__", "")
+            model_type = getattr(base, "model_type", None)
+            if module_name.startswith("transformers.models.") and model_type:
+                return model_type
+
+        return None
+
+    @classmethod
+    def from_dict(cls, config_dict: dict[str, Any], **kwargs) -> LightningIRConfig:
+        """Constructs a `LightningIRConfig` from a Python dictionary of parameters."""
+        if cls is LightningIRConfig or all(issubclass(base, LightningIRConfig) for base in cls.__bases__):
+            backbone_model_type = config_dict.get("backbone_model_type", None)
+            if backbone_model_type is not None:
+                from transformers import CONFIG_MAPPING
+
+                backbone_config_class = CONFIG_MAPPING[backbone_model_type]
+                if cls is not LightningIRConfig:
+                    ConfigClass = cls
+                else:
+                    factory_result = LightningIRConfigClassFactory.get_lightning_ir_config(
+                        config_dict.get("model_type")
+                    )
+                    ConfigClass = type(factory_result)
+
+                if ConfigClass is not LightningIRConfig:
+                    cls = LightningIRConfigClassFactory(ConfigClass).from_backbone_class(backbone_config_class)
+        return super().from_dict(config_dict, **kwargs)
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: str | Path, *args, **kwargs) -> LightningIRConfig:
@@ -127,6 +175,6 @@ https://huggingface.co/docs/transformers/en/main_classes/configuration#transform
             cls = LightningIRConfigClassFactory(ConfigClass).from_backbone_class(type(backbone_config))
             if config is not None and all(issubclass(base, LightningIRConfig) for base in config.__class__.__bases__):
                 derived_config = cls.from_pretrained(pretrained_model_name_or_path, config=config)
-                derived_config.update(config.to_dict())
+                derived_config.update(_drop_none_backbone_model_type(config.to_dict()))
             return cls.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
         return super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)

--- a/lightning_ir/base/external_model_hub.py
+++ b/lightning_ir/base/external_model_hub.py
@@ -14,7 +14,8 @@ Attributes:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .config import LightningIRConfig

--- a/lightning_ir/base/model.py
+++ b/lightning_ir/base/model.py
@@ -17,7 +17,7 @@ from transformers.modeling_outputs import ModelOutput
 
 from .adapter import LightningIRAdapterMixin
 from .class_factory import LightningIRModelClassFactory, _get_model_class
-from .config import LightningIRConfig
+from .config import LightningIRConfig, _drop_none_backbone_model_type
 from .external_model_hub import (
     BACKBONE_MAPPING,
     CHECKPOINT_MAPPING,
@@ -96,7 +96,7 @@ https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrai
 
     def _init_weights(self, module: torch.nn.Module) -> None:
         super()._init_weights(module)
-        if self.config.backbone_model_type == "modernbert":
+        if self.config.get_backbone_model_type() == "modernbert":
             # NOTE modernbert does not initialize the weights of non-modernbert layers
             # So we need to initialize them separately using the default initialization of the PreTrainedModel
             PreTrainedModel._init_weights(self, module)
@@ -174,7 +174,7 @@ https://huggingface.co/transformers/main_classes/model.html#transformers.PreTrai
             if config is not None:
                 if all(issubclass(base, LightningIRConfig) for base in config.__class__.__bases__):
                     derived_config = cls.config_class.from_pretrained(model_name_or_path, config=config)
-                    derived_config.update(config.to_diff_dict())
+                    derived_config.update(_drop_none_backbone_model_type(config.to_diff_dict()))
                     config = derived_config
                     kwargs["config"] = config
                 # NOTE 'config' is contained in kwargs, so we can update it

--- a/lightning_ir/base/tokenizer.py
+++ b/lightning_ir/base/tokenizer.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from os import PathLike
 from typing import Self
 
-from transformers import TOKENIZER_MAPPING, BatchEncoding, PreTrainedTokenizerBase
+from transformers import TOKENIZER_MAPPING, AutoTokenizer, BatchEncoding, PreTrainedTokenizerBase
 
 from .class_factory import LightningIRTokenizerClassFactory
 from .config import LightningIRConfig
@@ -99,11 +99,21 @@ https://huggingface.co/docs/transformers/main_classes/tokenizer.html#transformer
                     raise ValueError("Pass a config to `from_pretrained`.")
             ConfigClass = getattr(ConfigClass, "mixin_config", ConfigClass)
             backbone_config = LightningIRTokenizerClassFactory.get_backbone_config(model_name_or_path)
-            BackboneTokenizers = TOKENIZER_MAPPING[type(backbone_config)]
-            if kwargs.get("use_fast", True):
-                BackboneTokenizer = BackboneTokenizers[1]
+            try:
+                BackboneTokenizers = TOKENIZER_MAPPING[type(backbone_config)]
+            except KeyError:
+                tokenizer_kwargs = dict(kwargs)
+                tokenizer_kwargs.pop("config", None)
+                BackboneTokenizer = AutoTokenizer.from_pretrained(
+                    model_name_or_path, *args, **tokenizer_kwargs
+                ).__class__
             else:
-                BackboneTokenizer = BackboneTokenizers[0]
+                if not isinstance(BackboneTokenizers, tuple):
+                    BackboneTokenizer = BackboneTokenizers
+                elif kwargs.get("use_fast", True):
+                    BackboneTokenizer = BackboneTokenizers[1]
+                else:
+                    BackboneTokenizer = BackboneTokenizers[0]
             cls = LightningIRTokenizerClassFactory(ConfigClass).from_backbone_class(BackboneTokenizer)
             return cls.from_pretrained(model_name_or_path, *args, **kwargs)
         config = kwargs.pop("config", None)

--- a/lightning_ir/bi_encoder/bi_encoder_config.py
+++ b/lightning_ir/bi_encoder/bi_encoder_config.py
@@ -47,7 +47,11 @@ class BiEncoderConfig(LightningIRConfig):
         self.normalization_strategy = normalization_strategy
         self.sparsification_strategy = sparsification_strategy
         self.add_marker_tokens = add_marker_tokens
-        self.embedding_dim: int | None = getattr(self, "hidden_size", None)
+
+        _embedding_dim = kwargs.get("embedding_dim", None)
+        if _embedding_dim is None:
+            _embedding_dim = getattr(self, "hidden_size", None)
+        self.embedding_dim = _embedding_dim
 
     def to_diff_dict(self) -> dict[str, Any]:
         """
@@ -59,7 +63,14 @@ class BiEncoderConfig(LightningIRConfig):
             dict[str, Any]: Dictionary of all the attributes that make up this configuration instance.
         """
         diff_dict = super().to_diff_dict()
-        diff_dict.pop("embedding_dim", None)  # Exclude embedding_dim from diff_dict
+        try:
+            embedding_dim = self.embedding_dim
+        except (ValueError, AttributeError):
+            embedding_dim = None
+        if embedding_dim is not None:
+            diff_dict["embedding_dim"] = embedding_dim
+        else:
+            diff_dict.pop("embedding_dim", None)
         return diff_dict
 
 

--- a/lightning_ir/bi_encoder/bi_encoder_model.py
+++ b/lightning_ir/bi_encoder/bi_encoder_model.py
@@ -343,7 +343,7 @@ class MultiVectorBiEncoderModel(BiEncoderModel):
             setattr(
                 self,
                 f"{sequence}_mask_scoring_input_ids",
-                torch.tensor(mask_scoring_input_ids, dtype=torch.long),
+                torch.tensor(mask_scoring_input_ids, dtype=torch.long, device="cpu"),
             )
 
     def _expand_mask(self, shape: torch.Size, mask: torch.Tensor, dim: int) -> torch.Tensor:

--- a/lightning_ir/callbacks/callbacks.py
+++ b/lightning_ir/callbacks/callbacks.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import csv
 import gc
 import itertools
+from collections.abc import Callable
 from dataclasses import is_dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import pandas as pd
 import torch

--- a/lightning_ir/cross_encoder/cross_encoder_tokenizer.py
+++ b/lightning_ir/cross_encoder/cross_encoder_tokenizer.py
@@ -107,8 +107,12 @@ class CrossEncoderTokenizer(LightningIRTokenizer):
         num_docs: Sequence[int],
     ) -> tuple[str | Sequence[str], str | Sequence[str]]:
         """Preprocesses queries and documents to ensure that they are truncated their respective maximum lengths."""
-        truncated_queries = self._repeat_queries(self._truncate(queries, self.query_length), num_docs)
+        truncated_queries = self._truncate(queries, self.query_length)
         truncated_docs = self._truncate(docs, self.doc_length)
+        if self.post_processor is not None:
+            truncated_queries = [f" {query}" for query in truncated_queries]
+            truncated_docs = [f" {doc}" for doc in truncated_docs]
+        truncated_queries = self._repeat_queries(truncated_queries, num_docs)
         return truncated_queries, truncated_docs
 
     def _process_num_docs(

--- a/lightning_ir/data/dataset.py
+++ b/lightning_ir/data/dataset.py
@@ -642,7 +642,7 @@ class RunDataset(IRDataset, Dataset):
             filtered = group.set_index("doc_id").loc[list(doc_ids)].filter(like=self.targets).fillna(0)
             if filtered.empty:
                 raise ValueError(f"targets `{self.targets}` not found in run file")
-            targets = torch.from_numpy(filtered.values)
+            targets = torch.from_numpy(filtered.values).to(torch.float32)
             if self.targets == "rank":
                 # invert ranks to be higher is better (necessary for loss functions)
                 targets = self.depth - targets + 1
@@ -718,7 +718,7 @@ class TupleDataset(IRDataset, IterableDataset):
             query = self.queries.loc[query_id]
             doc_ids, docs, targets = self._parse_sample(sample)
             if targets is not None:
-                targets = torch.tensor(targets)
+                targets = torch.tensor(targets, dtype=torch.float32)
             yield RankSample(query_id, query, doc_ids, docs, targets)
 
     def prepare_data(self) -> None:

--- a/lightning_ir/modeling_utils/batching.py
+++ b/lightning_ir/modeling_utils/batching.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable
 
 import torch
 

--- a/lightning_ir/models/bi_encoders/splade.py
+++ b/lightning_ir/models/bi_encoders/splade.py
@@ -112,10 +112,23 @@ class SpladeModel(SingleVectorBiEncoderModel):
         """
         super().__init__(config, *args, **kwargs)
         # grab language modeling head based on backbone model type
-        layer_cls = MODEL_TYPE_TO_LM_HEAD[config.backbone_model_type or config.model_type]
+        backbone_model_type = config.get_backbone_model_type() or config.model_type
+        layer_cls = MODEL_TYPE_TO_LM_HEAD[backbone_model_type]
         self.projection = layer_cls(config)
-        tied_weight_keys = (getattr(self, "_tied_weights_keys", []) or []) + ["projection.decoder.weight"]
-        self._tied_weights_keys = tied_weight_keys
+        tied_weights_keys = getattr(self, "_tied_weights_keys", None)
+        if not isinstance(tied_weights_keys, dict):
+            tied_weights_keys = {}
+        else:
+            tied_weights_keys = dict(tied_weights_keys)
+        tied_weights_keys["projection.decoder.weight"] = "embeddings.word_embeddings.weight"
+        self._tied_weights_keys = tied_weights_keys
+        all_tied_weights_keys = getattr(self, "all_tied_weights_keys", None)
+        if not isinstance(all_tied_weights_keys, dict):
+            all_tied_weights_keys = {}
+        else:
+            all_tied_weights_keys = dict(all_tied_weights_keys)
+        all_tied_weights_keys["projection.decoder.weight"] = "embeddings.word_embeddings.weight"
+        self.all_tied_weights_keys = all_tied_weights_keys
         self.query_weights = None
         if config.query_weighting == "static":
             self.query_weights = torch.nn.Embedding(config.vocab_size, 1)
@@ -192,8 +205,21 @@ class SpladeModel(SingleVectorBiEncoderModel):
         """
         key_mapping = kwargs.pop("key_mapping", {})
         config = cls.config_class
+
         # map mlm projection keys
-        model_type = config.backbone_model_type or config.model_type
+        if isinstance(config, type):
+            backbone_model_type = getattr(config, "backbone_model_type", None)
+            if backbone_model_type is None:
+                for base in config.__mro__[1:]:
+                    module_name = getattr(base, "__module__", "")
+                    model_type = getattr(base, "model_type", None)
+                    if module_name.startswith("transformers.models.") and model_type:
+                        backbone_model_type = model_type
+                        break
+            model_type = backbone_model_type or getattr(config, "model_type", None)
+        else:
+            model_type = config.get_backbone_model_type() or config.model_type
+
         if model_type in MODEL_TYPE_TO_STATE_DICT_KEY_MAPPING:
             key_mapping.update(MODEL_TYPE_TO_STATE_DICT_KEY_MAPPING[model_type])
         if not key_mapping:

--- a/lightning_ir/models/cross_encoders/mono.py
+++ b/lightning_ir/models/cross_encoders/mono.py
@@ -102,7 +102,7 @@ class MonoModel(CrossEncoderModel):
                 torch.nn.Linear(config.hidden_size, config.hidden_size), torch.nn.Tanh()
             )
 
-        if self.config.backbone_model_type == "t5":
+        if self.config.get_backbone_model_type() == "t5":
             self.linear = ScaleLinear(config.hidden_size, output_dim, bias=self.config.linear_bias)
         else:
             self.linear = torch.nn.Linear(config.hidden_size, output_dim, bias=self.config.linear_bias)

--- a/lightning_ir/models/cross_encoders/set_encoder.py
+++ b/lightning_ir/models/cross_encoders/set_encoder.py
@@ -77,9 +77,10 @@ class SetEncoderModel(MonoModel):
         super().__init__(config, *args, **kwargs)
         self.config: SetEncoderConfig
         self.attn_implementation = "eager"
-        if self.config.backbone_model_type is not None and self.config.backbone_model_type not in ("bert", "electra"):
+        backbone_model_type = self.config.get_backbone_model_type()
+        if backbone_model_type is not None and backbone_model_type not in ("bert", "electra"):
             raise ValueError(
-                f"SetEncoderModel does not support backbone model type {self.config.backbone_model_type}. "
+                f"SetEncoderModel does not support backbone model type {backbone_model_type}. "
                 f"Supported types are 'bert' and 'electra'."
             )
 
@@ -129,6 +130,20 @@ class SetEncoderModel(MonoModel):
             CrossEncoderOutput: Output of the model.
         """
         num_docs = encoding.pop("num_docs", None)
+        if num_docs is not None:
+            attention_mask = encoding.get("attention_mask")
+            if attention_mask is not None:
+                device = attention_mask.device
+                eye = (1 - torch.eye(self.config.depth, device=device)).long()
+                if not self.config.sample_missing_docs:
+                    eye = eye[:, : max(num_docs)]
+                other_doc_attention_mask = torch.cat([eye[:n] for n in num_docs])
+                attention_mask = torch.cat(
+                    [attention_mask, other_doc_attention_mask.to(attention_mask)],
+                    dim=-1,
+                )
+                encoding["attention_mask"] = attention_mask
+
         self.get_extended_attention_mask = partial(self.get_extended_attention_mask, num_docs=num_docs)
         for name, module in self.named_modules():
             if name.endswith(self.self_attention_pattern):
@@ -192,7 +207,7 @@ class SetEncoderModel(MonoModel):
         context = context.permute(0, 2, 1, 3).contiguous()
         new_context_shape = context.size()[:-2] + (self.all_head_size,)
         context = context.view(new_context_shape)
-        return (context,)
+        return (context, None)
 
     def cat_other_doc_hidden_states(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 test = [
     "pytest>=8,<10",
     "pytest-cov>=5,<8",
-    "sentence-transformers",
+    "sentence-transformers==5.3.0",
     "faiss-cpu",
     "pyseismic-lsr",
     "omegaconf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,15 @@ keywords = ["information-retrieval"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
-    "transformers[torch]>=4.50.0,<5.0.0",
+    "transformers[torch]>=5.0.0",
     "datasets>=3.0.0",
     "ir_datasets",
     "ir-measures",
@@ -73,9 +72,15 @@ include-package-data = true
 include = ["lightning_ir", "lightning_ir.*"]
 exclude = ["examples*", "docs*", "tests*"]
 
+[tool.pytest.ini_options]
+markers = [
+    "dataset: tests that require downloading datasets from external sources",
+    "model: tests that require downloading models from external sources",
+]
+
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,15 @@
 import os
+
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
+os.environ["NUMEXPR_NUM_THREADS"] = "1"
+
 import shutil
 from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 import pytest
 from _pytest.fixtures import SubRequest
@@ -69,7 +76,7 @@ DATA_DIR = Path(__file__).parent / "data"
 CORPUS_DIR = DATA_DIR / "corpus"
 RUNS_DIR = DATA_DIR / "runs"
 
-CONFIGS = Union[BiEncoderConfig, CrossEncoderConfig]
+CONFIGS = BiEncoderConfig | CrossEncoderConfig
 
 register_new_dataset(
     dataset_id="lightning-ir",
@@ -100,7 +107,7 @@ DATA_DIR = Path(__file__).parent / "data"
 
 GLOBAL_KWARGS: dict[str, Any] = {"query_length": 8, "doc_length": 8}
 
-BI_ENCODER_GLOBAL_KWARGS: dict[str, Any] = {"embedding_dim": 4}
+BI_ENCODER_GLOBAL_KWARGS: dict[str, Any] = {"embedding_dim": 128}
 
 BI_ENCODER_CONFIGS = {
     "CoilModel": CoilConfig(**GLOBAL_KWARGS, **BI_ENCODER_GLOBAL_KWARGS),

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,3 +1,4 @@
+import importlib.util
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -62,6 +63,10 @@ def test_index_callback(
             f"Indexing not supported for {bi_encoder_module.config.__class__.__name__} model "
             f"and {index_config.__class__.__name__} indexer"
         )
+
+    if "Seismic" in index_config.__class__.__name__:
+        if importlib.util.find_spec("seismic") is None:
+            pytest.skip("seismic package is not available")
 
     index_dir = tmp_path / "index"
     index_callback = IndexCallback(index_config=index_config, index_dir=index_dir)
@@ -160,6 +165,10 @@ def test_search_callback(
             f"Searching not supported for {bi_encoder_module.config.__class__.__name__} model and "
             f"{search_config.__class__.__name__} searcher"
         )
+
+    if "Seismic" in search_config.__class__.__name__:
+        if importlib.util.find_spec("seismic") is None:
+            pytest.skip("seismic package is not available")
 
     index_dir = get_index(bi_encoder_module, doc_datamodule, search_config)
     save_dir = tmp_path / "runs"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from lightning_ir.base.module import LightningIRModule
 def test_serialize_deserialize(module: LightningIRModule, tmp_path: Path):
     config = module.model.config
     config_class = module.model.config_class
+    assert config.backbone_model_type == "bert"
     save_dir = str(tmp_path / config_class.model_type)
     config.save_pretrained(save_dir)
     new_configs = [
@@ -26,6 +27,7 @@ def test_serialize_deserialize(module: LightningIRModule, tmp_path: Path):
                 "transformers_version",
                 "_attn_implementation_autoset",
                 "_attn_implementation_internal",
+                "_experts_implementation_internal",
             ):
                 continue
             assert getattr(new_config, key) == value

--- a/tests/test_models/test_coil.py
+++ b/tests/test_models/test_coil.py
@@ -71,6 +71,7 @@ class UniCoilEncoder(PreTrainedModel):
         self.bert = BertModel(config)
         self.tok_proj = torch.nn.Linear(config.hidden_size, 1)
         self.init_weights()
+        self.post_init()
 
     # Copied from transformers.models.bert.modeling_bert.BertPreTrainedModel._init_weights
     def _init_weights(self, module):
@@ -106,6 +107,17 @@ class UniCoilEncoder(PreTrainedModel):
         out = torch.zeros(input_shape[0], self.config.vocab_size, device=device)
         out = out.scatter(1, input_ids, tok_weights)
         return out
+
+
+def _load_unicoil_state_dict(model: UniCoilEncoder, hf_model: str) -> None:
+    state_dict_path = hf_hub_download(hf_model, filename="pytorch_model.bin")
+    state_dict = torch.load(state_dict_path, map_location="cpu")
+    state_dict = {
+        key.removeprefix("coil_encoder."): value
+        for key, value in state_dict.items()
+        if key.startswith(("coil_encoder.bert.", "coil_encoder.tok_proj."))
+    }
+    model.load_state_dict(state_dict, strict=False)
 
 
 @pytest.mark.model
@@ -174,6 +186,7 @@ def test_same_as_unicoil(hf_model: str):
     ]
 
     orig_model = UniCoilEncoder.from_pretrained(hf_model)
+    _load_unicoil_state_dict(orig_model, hf_model)
     orig_tokenizer = AutoTokenizer.from_pretrained(hf_model)
     orig_query_encoded = orig_tokenizer(
         query, padding=True, truncation=True, max_length=512, return_tensors="pt", return_token_type_ids=False

--- a/tests/test_models/test_col.py
+++ b/tests/test_models/test_col.py
@@ -4,6 +4,8 @@ import transformers
 
 transformers.AdamW = None  # monkey patch to avoid import error for original colbert
 
+import colbert.modeling.base_colbert as colbert_base  # noqa: E402
+import colbert.modeling.hf_colbert as colbert_hf  # noqa: E402
 from colbert.modeling.checkpoint import Checkpoint  # noqa: E402
 from colbert.modeling.colbert import ColBERTConfig, colbert_score  # noqa: E402
 from pylate import models, rank  # noqa: E402
@@ -20,6 +22,26 @@ def _get_model_type(*args, **kwargs):
 
 
 PyLateColbert._get_model_type = _get_model_type
+
+
+_colbert_class_factory = colbert_hf.class_factory
+
+
+def _class_factory_with_transformers_v5_tied_keys(*args, **kwargs):
+    model_class = _colbert_class_factory(*args, **kwargs)
+    if not hasattr(model_class, "all_tied_weights_keys"):
+        model_class.all_tied_weights_keys = {}
+
+    for attr in ("_keys_to_ignore_on_load_missing", "_keys_to_ignore_on_load_unexpected"):
+        value = getattr(model_class, attr, None)
+        if isinstance(value, list):
+            setattr(model_class, attr, set(value))
+
+    return model_class
+
+
+colbert_hf.class_factory = _class_factory_with_transformers_v5_tied_keys
+colbert_base.class_factory = _class_factory_with_transformers_v5_tied_keys
 
 
 @pytest.mark.model


### PR DESCRIPTION
This PR updates Lightning IR for compatibility with Transformers v5.

The main changes are:
- Update dynamic config/model/tokenizer class factories for Transformers v5 behavior.
- Preserve and resolve `backbone_model_type` more robustly when loading derived Lightning IR configs.
- Adapt model-specific logic for v5, including SPLADE tied-weight metadata and SetEncoder attention mask handling.
- Update tokenizer handling for newer tokenizer mappings and T5-style cross-encoder formatting.
- Normalize dataset training targets to `float32`.
- Add compatibility shims for external model comparison tests where upstream libraries still assume older Transformers internals.
- Stabilize shared test configuration and update typing for the Python 3.10+ baseline.
